### PR TITLE
version number normalized

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="BoxSDK-Cn",
-    version="0.0.6a",
+    version="0.0.6a0",
     description="Box-SDK-Cn",
     author="sebastian",
     author_email="seba@cloudnative.co.jp",


### PR DESCRIPTION
```sh
% python ./setup.py
/Users/isobe/.anyenv/envs/pyenv/versions/3.6.10/lib/python3.6/site-packages/setuptools/dist.py:470: UserWarning: Normalizing '0.0.6a' to '0.0.6a0'
  normalized_version,
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: no commands supplied
```